### PR TITLE
eng: Introduce flag to skip post-command hook BNCH-89430

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,10 @@ For example, you can calculate total checksum of your javascript folder to skip 
 
 Note: Before hashing files, we do sorting via `sort`. This makes exact same sorted and hashed content against very same directory between different builds.
 
+## Skip Post command Hook
+
+You can skip post command hook by simply adding `skip-post-command-hook: false`
+
 ## Skip Cache on PRs
 
 You can skip caching on Pull Requests (Merge Requests) by simply adding `pr: false` to the cache plugin. For example;

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Note: Before hashing files, we do sorting via `sort`. This makes exact same sort
 
 ## Skip Post command Hook
 
-You can skip post command hook by simply adding `skip-post-command-hook: false`
+You can skip post command hook by simply adding `skip-post-command-hook: true`
 
 ## Skip Cache on PRs
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -6,6 +6,10 @@
 
 set -euo pipefail
 
+if [[ "${BUILDKITE_PLUGIN_CACHE_SKIP_POST_COMMAND_HOOK:-false}" =~ (true|on|1) ]]; then
+  exit 0
+fi
+
 BK_CACHE_BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
 BK_CACHE_ID=""
 BK_LOG_PREFIX="(*) - "

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -7,6 +7,7 @@
 set -euo pipefail
 
 if [[ "${BUILDKITE_PLUGIN_CACHE_SKIP_POST_COMMAND_HOOK:-false}" =~ (true|on|1) ]]; then
+  echo -e "SKIP_POST_COMMAND_HOOK flag Detected. Skipping..."
   exit 0
 fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -23,6 +23,8 @@ configuration:
       type: boolean
     always:
       type: boolean
+    skip-post-command-hook:
+      type: boolean
     pipeline-slug-override:
       type: string
     pr:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -382,3 +382,22 @@ setup() {
   unstub mktemp
   unstub aws
 }
+
+
+@test "Post-command skips with flag" {
+
+  export BUILDKITE_PLUGIN_CACHE_SKIP_POST_COMMAND_HOOK="true"
+
+  run "$PWD/hooks/post-command"
+  assert_success
+  refute_output --partial ':bash: Processing'
+
+  unset BUILDKITE_PLUGIN_CACHE_SKIP_POST_COMMAND_HOOK
+}
+
+@test "Post-command is not skipped by default" {
+
+  run "$PWD/hooks/post-command"
+  assert_output --partial ':bash: Processing'
+
+}

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -399,6 +399,7 @@ setup() {
 @test "Post-command is not skipped by default" {
 
   run "$PWD/hooks/post-command"
+  refute_output --partial 'SKIP_POST_COMMAND_HOOK flag Detected. Skipping...'
   assert_output --partial ':bash: Processing'
 
 }

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -391,6 +391,7 @@ setup() {
   run "$PWD/hooks/post-command"
   assert_success
   refute_output --partial ':bash: Processing'
+  assert_output --partial 'SKIP_POST_COMMAND_HOOK flag Detected. Skipping...'
 
   unset BUILDKITE_PLUGIN_CACHE_SKIP_POST_COMMAND_HOOK
 }


### PR DESCRIPTION
Description
---
This PR introduce a new flag to completely skip post-command hook


Testing Done
---

Test PR: https://github.com/benchling/aurelia/pull/116898/files

The post hook command is skipped in the webpack cache with the flag set
https://buildkite.com/benchling/integration-tests/builds/275049#_
<img width="903" alt="image" src="https://github.com/benchling/cache-buildkite-plugin/assets/66641495/8a8d17aa-cf07-41b4-aa65-48e876362ac7">


https://buildkite.com/benchling/monolith-tests/builds/420136#_
Prettier is unaffected without the flag update 
<img width="903" alt="image" src="https://github.com/benchling/cache-buildkite-plugin/assets/66641495/7351e670-a38a-4133-ad16-c593b20d1d50">

